### PR TITLE
bug fix - changed end to duration

### DIFF
--- a/controllers/api/participant-routes.js
+++ b/controllers/api/participant-routes.js
@@ -74,7 +74,7 @@ router.get('/meetings/:id', (req, res) => {
     {
       model: Meeting,
       attributes: ['id', 'date',
-        'start', 'end',
+        'start', 'duration',
         'meeting_name', 'topic'
       ],
     }]
@@ -111,7 +111,7 @@ router.get('/users/:id', (req, res) => {
     {
       model: Meeting,
       attributes: ['id', 'date',
-        'start', 'end',
+        'start', 'duration',
         'meeting_name', 'topic'
       ],
     }]


### PR DESCRIPTION
kate found that two perticipant routes still had the old database field "end" instead of the new one "duration - updated!