### PR TITLE
Bypassreload

### DIFF
--- a/controllers/dashboard-routes.js
+++ b/controllers/dashboard-routes.js
@@ -85,7 +85,8 @@ router.get("/", withAuth, (req, res) => {
             });
           res.render("dashboard", {
             participantObj: mappedParticipantArray,
-            meetingObj: mappedOrganizerArray
+            meetingObj: mappedOrganizerArray,
+            loggedIn: true
           });
         })
         .catch((err) => {

--- a/controllers/home-routes.js
+++ b/controllers/home-routes.js
@@ -3,10 +3,9 @@ const sequelize = require('../config/connection');
 const { Post, User, Comment } = require('../models');
 
 // render the  homepage
+// and pass logged-in status
 router.get('/', (req, res) => {
   console.log('======================');
-// No database calls here yet
-// TBD: Determine what goes on home page
   res.render('homepage', {
         loggedIn: req.session.loggedIn
       });

--- a/public/javascript/dashboard.js
+++ b/public/javascript/dashboard.js
@@ -25,6 +25,16 @@ async function toggleMeetingHandler(event) {
 
   //// otherwise....
 
+   // test of write to button
+ console.log(`event.target: ${event.target}`);
+
+ console.log(`event.target.innerhtml: ${event.target.innerhtml}`);
+
+  event.target.innerhtml = "I AM a FISH";
+ return
+
+
+
   const meeting_id = event.target.dataset.meeting;
   const user_id = event.target.dataset.participant;
   const statusText = event.target.dataset.status;
@@ -89,8 +99,9 @@ async function cancelMeetingHandler(event) {
   //// otherwise....
 
   const meeting_id = event.target.dataset.meeting;
-  // const user_id = event.target.dataset.organizer;
+  // const user_id = event.target.dataset.organizer; //future use
   // console.log(`meeting id: ${meeting_id} user_id: ${user_id}`);
+
 
   //////////////////////////////////////////////////
   //   DELETE the meeting

--- a/public/javascript/dashboard.js
+++ b/public/javascript/dashboard.js
@@ -1,20 +1,12 @@
 /////////////////////////////////////////////////
 //            dashboard.js
-/////////////////////////////////////////////////
-//  * event handlers for dashboard buttons
-//  * On the meetings you're invited to:
-//  * Toggle accept - three-way toggle for a 
-//    meeting from accepted to declined to "maybe" 
-//    and then stores the new value in the Particpant table.
-//
-///////////////////////////////////////////////////////////
-//
-//  * On the meetings you've organized
-//  * Cancel meeting
-//  * Deletes the meeting completely from the
-//  * Meetings table
-///////////////////////////////////////////////////////////
+//   event handlers for dashboard.handlebars
+////////////////////////////////////////////////
 
+///////////////////////////////////////////////////////////
+//  * toggleMeetingHandler - three-way toggle for a 
+//    meeting from accepted to declined to "maybe" 
+//    stores the new value in the Particpant table.
 
 async function toggleMeetingHandler(event) {
   event.preventDefault();
@@ -25,14 +17,8 @@ async function toggleMeetingHandler(event) {
 
   //// otherwise....
 
-   // test of write to button
- console.log(`event.target: ${event.target}`);
-
- console.log(`event.target.innerhtml: ${event.target.innerhtml}`);
-
-  event.target.innerhtml = "I AM a FISH";
- return
-
+  // test of write to button
+  //  event.target.textContent = "I AM a FISH";
 
 
   const meeting_id = event.target.dataset.meeting;
@@ -44,18 +30,31 @@ async function toggleMeetingHandler(event) {
   // console.log(`meeting id: ${meeting_id} user_id: ${user_id}`);
 
 
-  //   CAUTION: ///////////////////////////////////
+  //   NOTE: ///////////////////////////////////
   //   data-status in the html only sends the first word
   //   of "Not Sure" 
   ///////////////////////////////////////////////////////////
   // toggle the "accepted" flag through three states
   //      Accepted -> Declined -> Not Sure
-  //   convert back to boolean and store in the database
-  //   default "Not Sure" = null
+  //   convert back to boolean
+  //   change the text on the button (avoids page reload)
+  //   store new value in database
 
   let accepted = null;
-  if (statusText == "Accepted") accepted = false;
-  else if (statusText == "Not") accepted = true;
+  if (statusText == "Accepted") {
+    accepted = false;
+    event.target.dataset.status = "Declined";
+    event.target.textContent = "Declined";
+  }
+  else if (statusText == "Not") {
+    accepted = true;
+    event.target.dataset.status = "Accepted";
+    event.target.textContent = "Accepted";
+  }
+  else {
+    event.target.dataset.status = "Not";
+    event.target.textContent = "Not sure";
+  }
 
 
   // console.log(`NOW accepted: ${accepted}`);
@@ -77,9 +76,7 @@ async function toggleMeetingHandler(event) {
       'Content-Type': 'application/json'
     }
   });
-  if (response.ok) {
-    document.location.replace('/dashboard');
-  } else {
+  if (!response.ok) {
     alert(response.statusText);
   }
 }
@@ -97,6 +94,14 @@ async function cancelMeetingHandler(event) {
     return;
 
   //// otherwise....
+
+  //find the div.row this button is in
+  // and hide the row to avoid page reload
+  // vll: I think it does a page refresh anyway
+  //  so this is tbd
+
+  let rowEl = event.target.closest(".row")
+  rowEl.style.display = "none";
 
   const meeting_id = event.target.dataset.meeting;
   // const user_id = event.target.dataset.organizer; //future use

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -63,9 +63,13 @@ button, .btn-small, .btn {
   background-color: #c4752dff !important;
 }
 
-#logout {
-  margin-left: 10px;
+/* used for login and logout button */
+
+.btn-login {
+  margin-left: 15px;
+  display:inline
 }
+
 
 #homepage-img {
   width: 100%;

--- a/server.js
+++ b/server.js
@@ -41,7 +41,12 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use(require('./controllers/'));
 
-// vll: while we are debugging tables force:true
+// WHEN DATABASE CHANGES
+// use mySql to rebuild schema: "source ./db/schema.sql
+// set force:true HERE
+// start the server - this rebuilds our tables - and then quit
+// set force: false (IMPORTANT!) - now the database is good but all data is gone
+// reseed the database as desired. You can do this in mySQL with "source ./db/seeds.sql"
 sequelize.sync({ force: false }).then(() => {
   app.listen(PORT, () => console.log(`Server listening on: http://localhost:${PORT}`));
 });

--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -1,7 +1,7 @@
-{{!-- 
-  CALLED BY
+{{!-- CALLED BY
     controllers/home-routes.js
-    loggedIn indicates the user's req.session status--}}
+    loggedIn indicates the user's req.session status
+  --}}
 
 <div class="row">
   <div class="col l6 m12 s12" >

--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -1,14 +1,8 @@
 {{!-- 
-  DISPLAYS each blog post
   CALLED BY
     controllers/home-routes.js
-    res.render('homepage', {
-        posts,
-        loggedIn: req.session.loggedIn
-      }); 
-  CALLS
-    post-info.post 
-  --}}
+    loggedIn indicates the user's req.session status--}}
+
 <div class="row">
   <div class="col l6 m12 s12" >
     <img id="homepage-img" src="/assets/office-space.jpg" alt="Office space" < />

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -23,26 +23,37 @@
 
 
 </head>
+{{!-- called from home-routs.js
+{{loggedIn indicates the user's req.session status--}}
 
 <body>
   <header>
     <nav class="nav-wrapper">
       <div>
         <a href="/dashboard" class="brand-logo right">Your Dashboard <i class="material-icons">dock</i></a>
-        {{#if loggedIn}}
-        <button class="btn waves-effect waves-light" id="logout">Logout</button>
-        {{!-- {{else}} --}}
-        {{!-- if not logged in, they can click dashboard, but it
-          takes them to the login page --}}
-        {{!-- <a href="/login">Login</a> --}}
-        {{/if}}
+
+        {{!-- The other child of the navbar is either a login or logout button --}}
+        <div class="btn-login">
+          {{#if loggedIn}}
+          {{!-- make a logout button and attach even listener
+          on click, function logout will end the user session --}}
+          <button class="btn waves-effect waves-light" id="logout">Logout</button>
+          <script src="/javascript/logout.js"></script>
+          {{else}}
+          {{!-- make a button that links to the /login route
+          which sets up the user session --}}
+          <a href="/login">
+            <button class="btn waves-effect waves-light" id="login">Login</button>
+          </a>
+          {{/if}}
+        </div>
       </div>
     </nav>
   </header>
 
   <!-- Header + body -->
   <div class="container">
-     <h1> <a href="/">BACK 2 WORK</a> </h1>
+    <h1> <a href="/">BACK 2 WORK</a> </h1>
     <p class="subhead"> Meeting with your colleagues made easy.</p>
     <main>
       {{{ body }}}
@@ -56,10 +67,10 @@
     <p>© Back2Work 2021</p>
   </footer>
   </div>
-
+  {{!--
   {{#if loggedIn}}
   <script src="/javascript/logout.js"></script>
-  {{/if}}
+  {{/if}} --}}
 
   <!--Materialize cdn & initialization -->
   <script src="//cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>


### PR DESCRIPTION
Fixes the page jump when you change status on and "accept" button by writing the new status directly onto the button and committing to the db without going back through the dashboard.

Tried to do something similar on the cancel meeting - when button is clicked, the parent "row" is hidden and the db is updated without reloading the dashboard...but the browser still refreshes after the hide. Decided we could live with the reload but left the "hide row" code in in case we want to take it up again someday.